### PR TITLE
Update: ACE revive defaulted to OFF.

### DIFF
--- a/modules/ace_medical/params.hpp
+++ b/modules/ace_medical/params.hpp
@@ -1,7 +1,7 @@
 
 	class MedicalType {
 		title = "ACE Revive";
-		values[] = {0,1};
-		texts[] = {"Revive Off","Revive On"};
-		default = 1;
+		values[] = {0, 1};
+		texts[] = {"Revive Off", "Revive On"};
+		default = 0;
 	};


### PR DESCRIPTION
To better meet the needs of The Bear Cave community, ACE revive should be defaulted to OFF (still allowable to switch it to ON at the mission maker's discretion).